### PR TITLE
Add build script for Pyarmor obfuscation with ARM (AArch64) support

### DIFF
--- a/build_arm.sh
+++ b/build_arm.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Build script for Pyarmor obfuscation with ARM (AArch64) support
+# Usage: ./build_arm.sh <entry_script.py> <output_dir>
+
+ENTRY_SCRIPT=${1:-app.py}
+OUTPUT_DIR=${2:-dist}
+
+ARCH=$(uname -m)
+
+if [[ "$ARCH" == "aarch64" ]]; then
+    PLATFORM="linux.aarch64"
+    echo "Detected ARM64 architecture. Using platform: $PLATFORM"
+else
+    PLATFORM=""
+    echo "Detected architecture: $ARCH. Using default platform."
+fi
+
+if [[ -n "$PLATFORM" ]]; then
+    pyarmor gen --platform $PLATFORM --output "$OUTPUT_DIR" "$ENTRY_SCRIPT"
+else
+    pyarmor gen --output "$OUTPUT_DIR" "$ENTRY_SCRIPT"
+fi


### PR DESCRIPTION
To proceed with ARM (AArch64) support in your development workflow, you should add a build script that can detect the system architecture and run Pyarmor with the correct platform option. I will create a shell script named build_arm.sh in your project root that:

Detects if the system is ARM64 (AArch64) or x86_64.
Runs Pyarmor with the appropriate --platform option for ARM64 or defaults to the current platform.
You can use this script to generate obfuscated code for ARM (AArch64) or other platforms as needed.