### PR TITLE
Fix feature manager table visibility and search escaping

### DIFF
--- a/templates/settings/features.html
+++ b/templates/settings/features.html
@@ -104,7 +104,7 @@
 
     </div>
 
-    <div class="relative overflow-y-auto [&::-webkit-scrollbar]:w-2  [&::-webkit-scrollbar-track]:bg-gray-100  [&::-webkit-scrollbar-thumb]:bg-gray-300  dark:[&::-webkit-scrollbar-track]:bg-neutral-700  dark:[&::-webkit-scrollbar-thumb]:bg-neutral-500">
+    <div class="relative overflow-y-auto [&::-webkit-scrollbar]:w-2  [&::-webkit-scrollbar-track]:bg-gray-100  [&::-webkit-scrollbar-thumb]:bg-gray-300  dark:[&::-webkit-scrollbar-track]:bg-neutral-700  dark:[&::-webkit-scrollbar-thumb]:bg-neutral-500  pb-4">
         <table class="w-full caption-bottom border-b border-gray-200 dark:border-gray-800">
           <thead>
               <tr class="[&amp;_td:last-child]:pr-4 [&amp;_th:last-child]:pr-4 [&amp;_td:first-child]:pl-4 [&amp;_th:first-child]:pl-4 border-y border-gray-200 dark:border-gray-800">
@@ -122,7 +122,9 @@
             <tr x-data="{ enabled: {{ 'true' if plugin.status else 'false' }} }"
     x-effect="if (typeof toggleAll === 'boolean') enabled = toggleAll"
     data-row
-    x-show="searchQuery === '' || '{{ plugin.title }}'.toLowerCase().includes(searchQuery.toLowerCase()) || '{{ plugin.description }}'.toLowerCase().includes(searchQuery.toLowerCase())"
+    data-title="{{ plugin.title|e }}"
+    data-description="{{ plugin.description|e }}"
+    x-show="searchQuery === '' || ($el.dataset.title || '').toLowerCase().includes(searchQuery.toLowerCase()) || ($el.dataset.description || '').toLowerCase().includes(searchQuery.toLowerCase())"
     class="[&_td:last-child]:pr-4 [&_th:last-child]:pr-4 [&_td:first-child]:pl-4 [&_th:first-child]:pl-4 group select-none hover:bg-gray-50 hover:dark:bg-gray-900">
 
               <td class="p-4 text-sm text-right">
@@ -159,7 +161,9 @@
             <tr x-data="{ enabled: {{ 'true' if feature.status else 'false' }} }"
                 x-effect="if (typeof toggleAll === 'boolean') enabled = toggleAll"
                 data-row
-                x-show="searchQuery === '' || '{{ feature.title }}'.toLowerCase().includes(searchQuery.toLowerCase()) || '{{ feature.description }}'.toLowerCase().includes(searchQuery.toLowerCase())"
+                data-title="{{ feature.title|e }}"
+                data-description="{{ feature.description|e }}"
+                x-show="searchQuery === '' || ($el.dataset.title || '').toLowerCase().includes(searchQuery.toLowerCase()) || ($el.dataset.description || '').toLowerCase().includes(searchQuery.toLowerCase())"
                 class="hover:bg-gray-50 dark:hover:bg-gray-900">
 
               <td class="p-4 text-sm text-right">


### PR DESCRIPTION
Fix stefanpejcic/OpenPanel#953

Fixes two issues in the Feature Manager edit page:

- Prevents the last row in the features table from being hidden.
- Fixes Alpine x-show expression errors caused by unescaped quotes in feature/plugin descriptions.
<img width="694" height="423" alt="image" src="https://github.com/user-attachments/assets/d57f8aba-6694-4791-8534-5772ded064bd" />


The search logic now reads titles and descriptions from data attributes instead of injecting raw template values directly into Alpine expressions.